### PR TITLE
docs: Remove default for action

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const UPDATE = 'my-app/widgets/UPDATE';
 const REMOVE = 'my-app/widgets/REMOVE';
 
 // Reducer
-export default function reducer(state = {}, action = {}) {
+export default function reducer(state = {}, action) {
   switch (action.type) {
     // do reducer stuff
     default: return state;


### PR DESCRIPTION
While this is example code and doesn't necessarily have to be correct, the example will error if a default empty object is actually given for the action and then action.type is checked.
