### PR TITLE
Export default state

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ const UPDATE = 'my-app/widgets/UPDATE';
 const REMOVE = 'my-app/widgets/REMOVE';
 
 // Reducer
-export default function reducer(state = {}, action = {}) {
+export const defaultState = {};
+
+export default function reducer(state = defaultState, action = {}) {
   switch (action.type) {
     // do reducer stuff
     default: return state;
@@ -61,6 +63,7 @@ A module...
 2. MUST `export` its action creators as functions
 3. MUST have action types in the form `npm-module-or-app/reducer/ACTION_TYPE`
 3. MAY export its action types as `UPPER_SNAKE_CASE`, if an external reducer needs to listen for them, or if it is a published reusable library
+4. MAY export its default state
 
 These same guidelines are recommended for `{actionType, action, reducer}` bundles that are shared as reusable Redux libraries.
 


### PR DESCRIPTION
Now that we have React Hooks I've found the `ducks pattern` even more useful! With the `[useReducer](https://reactjs.org/docs/hooks-reference.html#usereducer)` hook I can easily switch a duck between using it with redux or a `useReducer`.

Now the `useReducer` hook require two pieces of data, the `reducer` and the `defaultState`. So in my own ducks I've had to also export my `defaultState` to be able to use it with a hook.

That way the usage with hooks becomes as follow:

```
import reducer, { defaultState } from 'some.ducks';
const MyComponent = () => {
   const [state, dispatch] = useReducer(reducer, defaultState);
   return <div>
   { state.somestate }
   </div>
}
```

This allows me to choose if I want to use the state locally for the component using `useReducer` or keep it globally in Redux. It also allows me to ex. start out with state in Redux for easy debugging and time traveling and then later take make the state component local if I see that I don't need it globally.

I hope you will accept this into the docs, as a consultant (doing both client work and developer training) I love being able to refer colleagues back to this repo as the "canonical" definition of the `Ducks pattern`.