### PR TITLE
docs: remove CodeFund sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-<p align="center">
-<a href="https://codefund.io/properties/555/visit-sponsor">
-<img src="https://codefund.io/properties/555/sponsor" />
-</a>
-</p>
-    
 # Ducks: Redux Reducer Bundles
 
 <img src="duck.jpg" align="right"/>


### PR DESCRIPTION
**What**:

Remove CodeFund sponsor ad from the README

**Why**:

CodeFund is not allowed to place ads on README's anymore according to GitHub.
Please reach out to our team if you have any questions :slightly_smiling_face: 